### PR TITLE
Dirname should not get null parameter in PHP 8.1

### DIFF
--- a/src/classes/Template.php
+++ b/src/classes/Template.php
@@ -31,7 +31,7 @@ class Template extends \Kirby\Cms\Template
     public function __construct(string $name, string $contentType = 'html', string $defaultType = 'html')
     {
         parent::__construct($name, $contentType, $defaultType);
-        $viewPath    = dirname($this->file());
+        $viewPath = dirname(isset($file) ? $file : '.');
         static::$twig = new Environment($viewPath);
     }
 


### PR DESCRIPTION
Since PHP 8.1 passing null to non-nullable internal function parameters is deprecated (https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation).
PHP 8.1 is already stable and Kirby supports it, so when I tried to update I came across the exception thrown from this plugin.

In the Template.php file's constructor, the dirname function's parameter comes from the file() function which can return null. An added null-check can prevent this.