### PR TITLE
Update namespace example calling the Kirby object to use ready option

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -6,8 +6,20 @@
 // Define a directory as a Twig namespace, that can be used as:
 //   {% include '@mynamespace/something.twig' %}
 'amteich.twig.namespaces' => [
-  'mynamespace' => kirby()->roots()->index() . '/mydirectory',
+  'mynamespace' => 'mydirectory',
 ],
+
+// Define a directory as a Twig namespace using a path given by Kirby.
+// Must be called in Kirby's 'ready' option to have access to the Kirby object.
+// Can be used as:
+//   {% include '@mynamespace/something.twig' %}
+'ready' => function () {
+  return [
+    'amteich.twig.namespaces' => [
+      'mynamespace' => kirby()->root()->index() . '/mydirectory',
+    ]
+  ];
+},
 
 // Load an extension
 'amteich.twig.extension.intl' => 'Twig\\Extra\\Intl\\IntlExtension',


### PR DESCRIPTION
The example before demonstrated how to build a path with the Kirby object, yet that example
couldn't work as the Kirby object is not available in the config, unless it is called in the
'ready' option of the config.