### PR TITLE
Fix example code for registering Twig extensions

### DIFF
--- a/doc/options.md
+++ b/doc/options.md
@@ -22,7 +22,7 @@
 },
 
 // Load an extension
-'amteich.twig.extension.intl' => 'Twig\\Extra\\Intl\\IntlExtension',
+'amteich.twig.env.extensions.intl' => 'Twig\\Extra\\Intl\\IntlExtension',
 
 // Expose an existing function in templates
 'amteich.twig.env.functions' => [


### PR DESCRIPTION
The example code in the documentation is incorrect. It uses `amteich.twig.extension` as the option key for registering extensions, but the `Environment` class actually looks for an option `amteich.twig.env.extensions`.